### PR TITLE
Double click to play sound

### DIFF
--- a/DCSB.Views/MainWindow/CounterListView.xaml
+++ b/DCSB.Views/MainWindow/CounterListView.xaml
@@ -59,7 +59,6 @@
 
         <DataGrid ItemsSource="{Binding ConfigurationModel.SelectedPreset.CounterCollection}" 
                   SelectedItem="{Binding ConfigurationModel.SelectedPreset.SelectedCounter, Mode=TwoWay}"
-                  Interactivity:Commands.DoubleClickCommand="{Binding OpenCounterCommand}"
                   AutoGenerateColumns="False"
                   CanUserReorderColumns="False"
                   SelectionMode="Single"

--- a/DCSB.Views/MainWindow/SoundListView.xaml
+++ b/DCSB.Views/MainWindow/SoundListView.xaml
@@ -82,7 +82,7 @@
             <Controls:IconButton DockPanel.Dock="Right" 
                                  Content="{StaticResource PlayIcon}" 
                                  Margin="2"
-                                 Command="{Binding PlayCommand}"
+                                 Command="{Binding ContinueCommand}"
                                  ToolTip="Play" />
             <Controls:IconButton DockPanel.Dock="Right" 
                                  Content="{StaticResource PauseIcon}" 
@@ -99,7 +99,7 @@
 
         <DataGrid ItemsSource="{Binding ConfigurationModel.SelectedPreset.SoundCollection}" 
                   SelectedItem="{Binding ConfigurationModel.SelectedPreset.SelectedSound, Mode=TwoWay}"
-                  Interactivity:Commands.DoubleClickCommand="{Binding OpenSoundCommand}"
+                  Interactivity:Commands.DoubleClickCommand="{Binding PlayCommand}"
                   AutoGenerateColumns="False"
                   CanUserReorderColumns="False"
                   SelectionMode="Single"


### PR DESCRIPTION
Remove doubleclick command from counters.
Change doubleclick command on sounds to play instead of edit.
Change play button command to continue instead of play.