### PR TITLE
Add more preset management

### DIFF
--- a/AssemblyVersionInfo.cs
+++ b/AssemblyVersionInfo.cs
@@ -10,5 +10,5 @@
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.0.0.2")]
-[assembly: AssemblyFileVersion("4.0.0.2")]
+[assembly: AssemblyVersion("4.0.0.4")]
+[assembly: AssemblyFileVersion("4.0.0.4")]

--- a/DCSB.Business/ShortcutManager.cs
+++ b/DCSB.Business/ShortcutManager.cs
@@ -8,16 +8,31 @@ namespace DCSB.Business
 {
     public class ShortcutManager
     {
+        private ApplicationStateModel _applicationStateModel;
         private ConfigurationModel _configurationModel;
         private SoundManager _soundManager;
 
         private Random _random;
 
-        public ShortcutManager(ConfigurationModel configurationModel, SoundManager soundManager)
+        public ShortcutManager(ApplicationStateModel applicationStateModel, ConfigurationModel configurationModel, SoundManager soundManager)
         {
+            _applicationStateModel = applicationStateModel;
             _configurationModel = configurationModel;
             _soundManager = soundManager;
             _random = new Random();
+        }
+
+        public void KeyUp(VKey key, List<VKey> pressedKeys)
+        {
+            if (_applicationStateModel.ModifiedBindable != null)
+            {
+                _applicationStateModel.ModifiedBindable.Keys.Clear();
+                foreach (VKey pressedKey in pressedKeys)
+                    _applicationStateModel.ModifiedBindable.Keys.Add(pressedKey);
+
+                _applicationStateModel.BindKeysOpened = false;
+                _applicationStateModel.ModifiedBindable = null;
+            }
         }
 
         public void KeyDown(VKey key, List<VKey> pressedKeys)

--- a/DCSB.Business/ShortcutManager.cs
+++ b/DCSB.Business/ShortcutManager.cs
@@ -82,6 +82,10 @@ namespace DCSB.Business
             if (preset != null)
             {
                 _configurationModel.SelectedPreset = preset;
+                foreach (Counter counter in preset.CounterCollection)
+                {
+                    counter.ReadFromFile();
+                }
             }
         }
 

--- a/DCSB.Icons/Buttons.xaml
+++ b/DCSB.Icons/Buttons.xaml
@@ -39,5 +39,15 @@
           Stretch="Uniform" Data="M11,18H13V16H11V18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M
           12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,6A4,4 0 0,0 8,10H10A
           2,2 0 0,1 12,8A2,2 0 0,1 14,10C14,12 11,11.75 11,15H13C13,12.75 16,12.5 16,10A4,4 0 0,0 12,6Z" />
+
+    <Path x:Shared="False" x:Key="CopyIcon" Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" 
+          Stretch="Uniform" Data="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H
+          4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
+
+    <Path x:Shared="False" x:Key="RightArrowIcon" Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" 
+          Stretch="Uniform" Data="M4,15V9H12V4.16L19.84,12L12,19.84V15H4Z" />
+
+    <Path x:Shared="False" x:Key="LeftArrowIcon" Fill="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" 
+          Stretch="Uniform" Data="M20,9V15H12V19.84L4.16,12L12,4.16V9H20Z" />
     
 </ResourceDictionary>

--- a/DCSB.Interactivity/AttachedProperties.cs
+++ b/DCSB.Interactivity/AttachedProperties.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DCSB.Interactivity
+{
+    public static class AttachedProperties
+    {
+        public static IList GetSelectedItems(ListBox obj)
+        {
+            return (IList)obj.GetValue(SelectedItemsProperty);
+        }
+
+        public static void SetSelectedItems(ListBox obj, IList value)
+        {
+            obj.SetValue(SelectedItemsProperty, value);
+        }
+
+        public static readonly DependencyProperty
+            SelectedItemsProperty =
+                DependencyProperty.RegisterAttached(
+                    "SelectedItems",
+                    typeof(IList),
+                    typeof(AttachedProperties),
+                    new PropertyMetadata(null,
+                        SelectedItems_PropertyChanged));
+
+        private static void SelectedItems_PropertyChanged(
+            DependencyObject sender,
+            DependencyPropertyChangedEventArgs e)
+        {
+            if (sender is ListBox listBox && e.NewValue is IList newCollection)
+            {
+                if (newCollection.Count > 0)
+                {
+                    listBox.SelectedItems.Clear();
+                    foreach (object item in newCollection)
+                    {
+                        listBox.SelectedItems.Add(item);
+                    }
+                }
+
+                listBox.SelectionChanged += (s, e2) =>
+                {
+                    if (e2.RemovedItems != null)
+                    {
+                        foreach (object item in e2.RemovedItems)
+                        {
+                            newCollection.Remove(item);
+                        }
+                    }
+                    if (e2.AddedItems != null)
+                    {
+                        foreach (object item in e2.AddedItems)
+                        {
+                            newCollection.Add(item);
+                        }
+                    }
+                };
+            }           
+        }
+    }
+}

--- a/DCSB.Interactivity/DCSB.Interactivity.csproj
+++ b/DCSB.Interactivity/DCSB.Interactivity.csproj
@@ -50,6 +50,7 @@
     <Compile Include="..\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="AttachedProperties.cs" />
     <Compile Include="Commands.cs" />
     <Compile Include="OpenCloseWindowBehavior.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/DCSB.Models/ApplicationStateModel.cs
+++ b/DCSB.Models/ApplicationStateModel.cs
@@ -1,0 +1,95 @@
+﻿using GalaSoft.MvvmLight;
+
+namespace DCSB.Models
+{
+    public class ApplicationStateModel : ObservableObject
+    {
+        private bool _settingsOpened;
+        public bool SettingsOpened
+        {
+            get { return _settingsOpened; }
+            set
+            {
+                _settingsOpened = value;
+                RaisePropertyChanged("SettingsOpened");
+            }
+        }
+
+        private bool _soundOpened;
+        public bool SoundOpened
+        {
+            get { return _soundOpened; }
+            set
+            {
+                _soundOpened = value;
+                RaisePropertyChanged("SoundOpened");
+            }
+        }
+
+        private bool _counterOpened;
+        public bool CounterOpened
+        {
+            get { return _counterOpened; }
+            set
+            {
+                _counterOpened = value;
+                RaisePropertyChanged("CounterOpened");
+            }
+        }
+
+        private bool _bindKeysOpened;
+        public bool BindKeysOpened
+        {
+            get { return _bindKeysOpened; }
+            set
+            {
+                _bindKeysOpened = value;
+                RaisePropertyChanged("BindKeysOpened");
+            }
+        }
+
+        private bool _aboutOpened;
+        public bool AboutOpened
+        {
+            get { return _aboutOpened; }
+            set
+            {
+                _aboutOpened = value;
+                RaisePropertyChanged("AboutOpened");
+            }
+        }
+
+        private IBindable _modifiedBindable;
+        public IBindable ModifiedBindable
+        {
+            get { return _modifiedBindable; }
+            set
+            {
+                _modifiedBindable = value;
+                RaisePropertyChanged("ModifiedBindable");
+            }
+        }
+
+        private Counter _modifiedCounter;
+        public Counter ModifiedCounter
+        {
+            get { return _modifiedCounter; }
+            set
+            {
+                _modifiedCounter = value;
+                RaisePropertyChanged("ModifiedCounter");
+            }
+        }
+
+        private Sound _modifiedSound;
+        public Sound ModifiedSound
+        {
+            get { return _modifiedSound; }
+            set
+            {
+                _modifiedSound = value;
+                RaisePropertyChanged("ModifiedSound");
+            }
+        }
+    }
+}

--- a/DCSB.Models/Counter.cs
+++ b/DCSB.Models/Counter.cs
@@ -5,7 +5,7 @@ using System.Xml.Serialization;
 
 namespace DCSB.Models
 {
-    public class Counter : ObservableObject
+    public class Counter : ObservableObject, ICloneable
     {
         private string _name;
         [XmlElement(Order = 1)]
@@ -86,6 +86,11 @@ namespace DCSB.Models
         {
             Format = "{0}";
             Increment = 1;
+        }
+
+        public object Clone()
+        {
+            return new Counter() { Name = Name, Increment = Increment, Format = Format, File = File, Count = Count };
         }
 
         private void WriteToFile()

--- a/DCSB.Models/Counter.cs
+++ b/DCSB.Models/Counter.cs
@@ -93,7 +93,7 @@ namespace DCSB.Models
             return new Counter() { Name = Name, Increment = Increment, Format = Format, File = File, Count = Count };
         }
 
-        private void WriteToFile()
+        public void WriteToFile()
         {
             Error = null;
             if (System.IO.File.Exists(File))
@@ -123,7 +123,7 @@ namespace DCSB.Models
             }
         }
 
-        private void ReadFromFile()
+        public void ReadFromFile()
         {
             Error = null;
             if (System.IO.File.Exists(File))

--- a/DCSB.Models/DCSB.Models.csproj
+++ b/DCSB.Models/DCSB.Models.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="ApplicationStateModel.cs" />
     <Compile Include="Counter.cs" />
     <Compile Include="IBindable.cs" />
     <Compile Include="ObservableObjectCollection.cs" />

--- a/DCSB.Models/Preset.cs
+++ b/DCSB.Models/Preset.cs
@@ -2,10 +2,12 @@
 using DCSB.Utils;
 using System.Collections.ObjectModel;
 using System.Xml.Serialization;
+using System;
+using System.Linq;
 
 namespace DCSB.Models
 {
-    public class Preset : ObservableObject, IBindable
+    public class Preset : ObservableObject, IBindable, ICloneable
     {
         private ObservableCollection<VKey> _keys;
         public ObservableCollection<VKey> Keys
@@ -86,6 +88,15 @@ namespace DCSB.Models
             CounterCollection.CollectionChanged += (sender, e) => RaisePropertyChanged("SelectedCounter");
             SoundCollection.CollectionChanged += (sender, e) => RaisePropertyChanged("SoundCollection");
             SoundCollection.CollectionChanged += (sender, e) => RaisePropertyChanged("SelectedSound");
+        }
+
+        public object Clone()
+        {
+            Preset clonedPreset = new Preset() { Name = $"{Name} copy" };
+            foreach (VKey key in Keys) clonedPreset.Keys.Add(key);
+            foreach (Counter counter in CounterCollection) clonedPreset.CounterCollection.Add((Counter)counter.Clone());
+            foreach (Sound sound in SoundCollection) clonedPreset.SoundCollection.Add((Sound)sound.Clone());
+            return clonedPreset;
         }
     }
 }

--- a/DCSB.Models/Sound.cs
+++ b/DCSB.Models/Sound.cs
@@ -1,14 +1,15 @@
 ﻿using DCSB.Utils;
 using System.Collections.ObjectModel;
 using System.Xml.Serialization;
-using System.Collections.Specialized;
 using System.IO;
 using System.Collections.Generic;
 using GalaSoft.MvvmLight;
+using System;
+using System.Linq;
 
 namespace DCSB.Models
 {
-    public class Sound : ObservableObject, IBindable
+    public class Sound : ObservableObject, IBindable, ICloneable
     {
         private string _name;
         public string Name
@@ -87,6 +88,14 @@ namespace DCSB.Models
             _files.CollectionChanged += (sender, e) => ValidateFiles();
 
             Volume = 100;
+        }
+
+        public object Clone()
+        {
+            Sound clonedSound = new Sound() { Name = Name, Volume = Volume, Loop = Loop };
+            foreach (string file in Files) clonedSound.Files.Add(file);
+            foreach (VKey key in Keys) clonedSound.Keys.Add(key);
+            return clonedSound;
         }
 
         private void ValidateFiles()

--- a/DCSB.ViewModels/DCSB.ViewModels.csproj
+++ b/DCSB.ViewModels/DCSB.ViewModels.csproj
@@ -61,6 +61,8 @@
     <Compile Include="..\AssemblyVersionInfo.cs">
       <Link>Properties\AssemblyVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="PresetConfigurationViewModel.cs" />
+    <Compile Include="PresetViewModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ViewModel.cs" />
   </ItemGroup>

--- a/DCSB.ViewModels/PresetConfigurationViewModel.cs
+++ b/DCSB.ViewModels/PresetConfigurationViewModel.cs
@@ -1,18 +1,24 @@
 ﻿using DCSB.Models;
 using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.Command;
+using System;
+using System.Collections.Generic;
+using System.Windows.Input;
 
 namespace DCSB.ViewModels
 {
     public class PresetConfigurationViewModel : ObservableObject
     {
         private ConfigurationModel _configurationModel;
+        private ApplicationStateModel _applicationStateModel;
 
-        public PresetConfigurationViewModel(ConfigurationModel configurationModel)
+        public PresetConfigurationViewModel(ApplicationStateModel applicationStateModel, ConfigurationModel configurationModel)
         {
+            _applicationStateModel = applicationStateModel;
             _configurationModel = configurationModel;
 
-            _leftPresetViewModel = new PresetViewModel(configurationModel);
-            _rightPresetViewModel = new PresetViewModel(configurationModel);
+            _leftPresetViewModel = new PresetViewModel(applicationStateModel, configurationModel);
+            _rightPresetViewModel = new PresetViewModel(applicationStateModel, configurationModel);
         }
 
         private PresetViewModel _leftPresetViewModel;
@@ -25,6 +31,54 @@ namespace DCSB.ViewModels
         public PresetViewModel RightPresetViewModel
         {
             get { return _rightPresetViewModel; }
+        }
+
+        public ICommand CopyCountersRightCommand
+        {
+            get { return new RelayCommand(CopyCountersRight); }
+        }
+        private void CopyCountersRight()
+        {
+            if (_rightPresetViewModel.SelectedPreset != null)
+                CopyItemsToList(_leftPresetViewModel.SelectedCounters, _rightPresetViewModel.SelectedPreset.CounterCollection);
+        }
+
+        public ICommand CopyCountersLeftCommand
+        {
+            get { return new RelayCommand(CopyCountersLeft); }
+        }
+        private void CopyCountersLeft()
+        {
+            if (_leftPresetViewModel.SelectedPreset != null)
+                CopyItemsToList(_rightPresetViewModel.SelectedCounters, _leftPresetViewModel.SelectedPreset.CounterCollection);
+        }
+
+        public ICommand CopySoundsRightCommand
+        {
+            get { return new RelayCommand(CopySoundsRight); }
+        }
+        private void CopySoundsRight()
+        {
+            if (_rightPresetViewModel.SelectedPreset != null)
+                CopyItemsToList(_leftPresetViewModel.SelectedSounds, _rightPresetViewModel.SelectedPreset.SoundCollection);
+        }
+
+        public ICommand CopySoundsLeftCommand
+        {
+            get { return new RelayCommand(CopySoundsLeft); }
+        }
+        private void CopySoundsLeft()
+        {
+            if (_leftPresetViewModel.SelectedPreset != null)
+                CopyItemsToList(_rightPresetViewModel.SelectedSounds, _leftPresetViewModel.SelectedPreset.SoundCollection);
+        }
+
+        private void CopyItemsToList<T>(IEnumerable<T> items, IList<T> list)
+        {
+            foreach (ICloneable item in items)
+            {
+                list.Add((T)item.Clone());
+            }
         }
     }
 }

--- a/DCSB.ViewModels/PresetConfigurationViewModel.cs
+++ b/DCSB.ViewModels/PresetConfigurationViewModel.cs
@@ -1,0 +1,30 @@
+﻿using DCSB.Models;
+using GalaSoft.MvvmLight;
+
+namespace DCSB.ViewModels
+{
+    public class PresetConfigurationViewModel : ObservableObject
+    {
+        private ConfigurationModel _configurationModel;
+
+        public PresetConfigurationViewModel(ConfigurationModel configurationModel)
+        {
+            _configurationModel = configurationModel;
+
+            _leftPresetViewModel = new PresetViewModel(configurationModel);
+            _rightPresetViewModel = new PresetViewModel(configurationModel);
+        }
+
+        private PresetViewModel _leftPresetViewModel;
+        public PresetViewModel LeftPresetViewModel
+        {
+            get { return _leftPresetViewModel; }
+        }
+
+        private PresetViewModel _rightPresetViewModel;
+        public PresetViewModel RightPresetViewModel
+        {
+            get { return _rightPresetViewModel; }
+        }
+    }
+}

--- a/DCSB.ViewModels/PresetViewModel.cs
+++ b/DCSB.ViewModels/PresetViewModel.cs
@@ -146,6 +146,40 @@ namespace DCSB.ViewModels
             _applicationStateModel.ModifiedBindable = null;
         }
 
+        public ICommand AddCounterCommand
+        {
+            get { return new RelayCommand(AddCounter); }
+        }
+        private void AddCounter()
+        {
+            if (SelectedPreset != null)
+            {
+                Counter counter = new Counter();
+                SelectedPreset.CounterCollection.Add(counter);
+                SelectedCounters.Clear();
+                SelectedCounters.Add(counter);
+                _applicationStateModel.ModifiedCounter = counter;
+                _applicationStateModel.CounterOpened = true;
+            }
+        }
+
+        public ICommand AddSoundCommand
+        {
+            get { return new RelayCommand(AddSound); }
+        }
+        private void AddSound()
+        {
+            if (SelectedPreset != null)
+            {
+                Sound sound = new Sound();
+                SelectedPreset.SoundCollection.Add(sound);
+                SelectedSounds.Clear();
+                SelectedSounds.Add(sound);
+                _applicationStateModel.ModifiedSound = sound;
+                _applicationStateModel.SoundOpened = true;
+            }
+        }
+
         public ICommand RemoveCountersCommand
         {
             get { return new RelayCommand(RemoveCounters); }

--- a/DCSB.ViewModels/PresetViewModel.cs
+++ b/DCSB.ViewModels/PresetViewModel.cs
@@ -1,0 +1,79 @@
+﻿using DCSB.Models;
+using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.Command;
+using System.Windows.Input;
+
+namespace DCSB.ViewModels
+{
+    public class PresetViewModel : ObservableObject
+    {
+        public PresetViewModel(ConfigurationModel configurationModel)
+        {
+            _configurationModel = configurationModel;
+        }
+
+        private ConfigurationModel _configurationModel;
+        public ConfigurationModel ConfigurationModel
+        {
+            get { return _configurationModel; }
+        }
+
+        private Preset _selectedPreset;
+        public Preset SelectedPreset
+        {
+            get { return _selectedPreset; }
+            set
+            {
+                _selectedPreset = value;
+                RaisePropertyChanged("SelectedPreset");
+            }
+        }
+
+        public ICommand AddPresetCommand
+        {
+            get { return new RelayCommand(AddPreset); }
+        }
+        private void AddPreset()
+        {
+            Preset preset = new Preset() { Name = "New Preset" };
+            _configurationModel.PresetCollection.Add(preset);
+            SelectedPreset = preset;
+        }
+
+        public ICommand RemovePresetCommand
+        {
+            get { return new RelayCommand(RemovePreset); }
+        }
+        private void RemovePreset()
+        {
+            if (SelectedPreset != null)
+            {
+                if (_configurationModel.PresetCollection.Count == 1)
+                {
+                    AddPreset();
+                    _configurationModel.PresetCollection.Remove(SelectedPreset);
+                }
+                else
+                {
+                    if (SelectedPreset == _configurationModel.SelectedPreset)
+                    {
+                        _configurationModel.SelectedPresetIndex = 0;
+                    }
+                    _configurationModel.PresetCollection.Remove(SelectedPreset);
+                }
+            }
+        }
+
+        public ICommand ClonePresetCommand
+        {
+            get { return new RelayCommand(ClonePreset); }
+        }
+        private void ClonePreset()
+        {
+            if (SelectedPreset != null)
+            {
+                _configurationModel.PresetCollection.Add((Preset)SelectedPreset.Clone());
+            }
+        }
+    }
+}

--- a/DCSB.ViewModels/PresetViewModel.cs
+++ b/DCSB.ViewModels/PresetViewModel.cs
@@ -1,15 +1,27 @@
 ﻿using DCSB.Models;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 
 namespace DCSB.ViewModels
 {
     public class PresetViewModel : ObservableObject
     {
-        public PresetViewModel(ConfigurationModel configurationModel)
+        public PresetViewModel(ApplicationStateModel applicationStateModel, ConfigurationModel configurationModel)
         {
+            _applicationStateModel = applicationStateModel;
             _configurationModel = configurationModel;
+
+            _selectedCounters = new ObservableCollection<Counter>();
+            _selectedSounds = new ObservableCollection<Sound>();
+        }
+
+        private ApplicationStateModel _applicationStateModel;
+        public ApplicationStateModel ApplicationStateModel
+        {
+            get { return _applicationStateModel; }
         }
 
         private ConfigurationModel _configurationModel;
@@ -26,6 +38,28 @@ namespace DCSB.ViewModels
             {
                 _selectedPreset = value;
                 RaisePropertyChanged("SelectedPreset");
+            }
+        }
+
+        private ObservableCollection<Counter> _selectedCounters;
+        public ObservableCollection<Counter> SelectedCounters
+        {
+            get { return _selectedCounters; }
+            set
+            {
+                _selectedCounters = value;
+                RaisePropertyChanged("SelectedCounters");
+            }
+        }
+
+        private ObservableCollection<Sound> _selectedSounds;
+        public ObservableCollection<Sound> SelectedSounds
+        {
+            get { return _selectedSounds; }
+            set
+            {
+                _selectedSounds = value;
+                RaisePropertyChanged("SelectedSounds");
             }
         }
 
@@ -72,7 +106,95 @@ namespace DCSB.ViewModels
         {
             if (SelectedPreset != null)
             {
-                _configurationModel.PresetCollection.Add((Preset)SelectedPreset.Clone());
+                Preset preset = (Preset)SelectedPreset.Clone();
+                _configurationModel.PresetCollection.Add(preset);
+                SelectedPreset = preset;
+            }
+        }
+
+        public ICommand BindKeysCommand
+        {
+            get { return new RelayCommand<IBindable>(BindKeys); }
+        }
+        public void BindKeys(IBindable bindable)
+        {
+            if (bindable != null)
+            {
+                _applicationStateModel.ModifiedBindable = bindable;
+                _applicationStateModel.BindKeysOpened = true;
+            }
+        }
+
+        public ICommand CancelBindKeysCommand
+        {
+            get { return new RelayCommand(CancelBindKeys); }
+        }
+        public void CancelBindKeys()
+        {
+            _applicationStateModel.BindKeysOpened = false;
+            _applicationStateModel.ModifiedBindable = null;
+        }
+
+        public ICommand ClearKeysCommand
+        {
+            get { return new RelayCommand(ClearKeys); }
+        }
+        private void ClearKeys()
+        {
+            _applicationStateModel.BindKeysOpened = false;
+            _applicationStateModel.ModifiedBindable.Keys.Clear();
+            _applicationStateModel.ModifiedBindable = null;
+        }
+
+        public ICommand RemoveCountersCommand
+        {
+            get { return new RelayCommand(RemoveCounters); }
+        }
+        private void RemoveCounters()
+        {
+            RemoveItemsFromList(SelectedCounters, SelectedPreset.CounterCollection);
+        }
+
+        public ICommand RemoveSoundsCommand
+        {
+            get { return new RelayCommand(RemoveSounds); }
+        }
+        private void RemoveSounds()
+        {
+            RemoveItemsFromList(SelectedSounds, SelectedPreset.SoundCollection);
+        }
+
+        public ICommand OpenCounterCommand
+        {
+            get { return new RelayCommand(OpenCounter); }
+        }
+        private void OpenCounter()
+        {
+            if (SelectedCounters.Count > 0)
+            {
+                _applicationStateModel.ModifiedCounter = SelectedCounters[0];
+                _applicationStateModel.CounterOpened = true;
+            }
+        }
+
+        public ICommand OpenSoundCommand
+        {
+            get { return new RelayCommand(OpenSound); }
+        }
+        private void OpenSound()
+        {
+            if (SelectedSounds.Count > 0)
+            {
+                _applicationStateModel.ModifiedSound = SelectedSounds[0];
+                _applicationStateModel.SoundOpened = true;
+            }
+        }
+
+        private void RemoveItemsFromList<T>(IList<T> items, IList<T> list)
+        {
+            for (int i = items.Count - 1; i >= 0; i--)
+            {
+                list.Remove(items[i]);
             }
         }
     }

--- a/DCSB.ViewModels/ViewModel.cs
+++ b/DCSB.ViewModels/ViewModel.cs
@@ -249,6 +249,10 @@ namespace DCSB.ViewModels
         private void PresetSelected(Preset selectedPreset)
         {
             _configurationModel.SelectedPreset = selectedPreset;
+            foreach (Counter counter in selectedPreset.CounterCollection)
+            {
+                counter.ReadFromFile();
+            }
         }
 
         public ICommand OpenSettingsCommand
@@ -334,6 +338,7 @@ namespace DCSB.ViewModels
             Counter counter = new Counter();
             _configurationModel.SelectedPreset.CounterCollection.Add(counter);
             _configurationModel.SelectedPreset.SelectedCounter = counter;
+            _applicationStateModel.ModifiedCounter = counter;
             _applicationStateModel.CounterOpened = true;
         }
 
@@ -487,6 +492,7 @@ namespace DCSB.ViewModels
             Sound sound = new Sound();
             _configurationModel.SelectedPreset.SelectedSound = sound;
             _configurationModel.SelectedPreset.SoundCollection.Add(sound);
+            _applicationStateModel.ModifiedSound = sound;
             _applicationStateModel.SoundOpened = true;
         }
 
@@ -567,6 +573,15 @@ namespace DCSB.ViewModels
             _applicationStateModel.BindKeysOpened = false;
             _applicationStateModel.ModifiedBindable.Keys.Clear();
             _applicationStateModel.ModifiedBindable = null;
+        }
+
+        public ICommand ClosingCommand
+        {
+            get { return new RelayCommand(Closing); }
+        }
+        private void Closing()
+        {
+            _configurationManager.Dispose();
         }
 
         private bool AreCountersEnabled()

--- a/DCSB.ViewModels/ViewModel.cs
+++ b/DCSB.ViewModels/ViewModel.cs
@@ -21,8 +21,9 @@ namespace DCSB.ViewModels
         private ShortcutManager _shortcutManager;
         private SoundManager _soundManager;
         private UpdateManager _updateManager;
-
         private KeyboardInput _keyboardInput;
+
+        private PresetConfigurationViewModel _presetConfigurationViewModel;
 
         private double _previousVolume;
         private double _previousPrimaryVolume;
@@ -40,7 +41,7 @@ namespace DCSB.ViewModels
         {
             _configurationManager = new ConfigurationManager();
             _configurationModel = _configurationManager.Load();
-            if (_configurationModel.PresetCollection.Count == 0) AddPreset();
+            if (_configurationModel.PresetCollection.Count == 0) _configurationModel.PresetCollection.Add(new Preset() { Name = "New Preset" } );
             _openFileManager = new OpenFileManager();
 
             _soundManager = new SoundManager(_configurationModel.PrimaryOutputDevice, _configurationModel.SecondaryOutputDevice)
@@ -52,6 +53,8 @@ namespace DCSB.ViewModels
             };
             _shortcutManager = new ShortcutManager(_configurationModel, _soundManager);
             _updateManager = new UpdateManager();
+
+            _presetConfigurationViewModel = new PresetConfigurationViewModel(_configurationModel);
 
             _configurationModel.PropertyChanged += (sender, e) => _configurationManager.Save((ConfigurationModel)sender);
 
@@ -81,6 +84,11 @@ namespace DCSB.ViewModels
         public ConfigurationModel ConfigurationModel
         {
             get { return _configurationModel; }
+        }
+
+        public PresetConfigurationViewModel PresetConfigurationViewModel
+        {
+            get { return _presetConfigurationViewModel; }
         }
 
         public GridLength CountersWidth
@@ -282,39 +290,6 @@ namespace DCSB.ViewModels
         private async void CheckForUpdates()
         {
             await _updateManager.ManualUpdateCheck(Version);
-        }
-
-        public ICommand AddPresetCommand
-        {
-            get { return new RelayCommand(AddPreset); }
-        }
-        private void AddPreset()
-        {
-            Preset preset = new Preset() { Name = "New Preset" };
-            _configurationModel.PresetCollection.Add(preset);
-            _configurationModel.SelectedPreset = preset;
-        }
-
-        public ICommand RemovePresetCommand
-        {
-            get { return new RelayCommand(RemovePreset); }
-        }
-        private void RemovePreset()
-        {
-            if (_configurationModel.PresetCollection.Count == 1)
-            {
-                AddPreset();
-                _configurationModel.PresetCollection.RemoveAt(0);
-            }
-            else
-            {
-                Preset selected = _configurationModel.SelectedPreset;
-                if (_configurationModel.SelectedPresetIndex == _configurationModel.PresetCollection.Count - 1)
-                {
-                    _configurationModel.SelectedPresetIndex--;
-                }
-                _configurationModel.PresetCollection.Remove(selected);
-            }
         }
 
         public ICommand PresetSelectedCommand

--- a/DCSB.Views/CounterView.xaml
+++ b/DCSB.Views/CounterView.xaml
@@ -29,22 +29,22 @@
         </Grid.RowDefinitions>
 
         <Label Grid.Row="0" Grid.Column="0">Name:</Label>
-        <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ConfigurationModel.SelectedPreset.SelectedCounter.Name}" />
+        <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ApplicationStateModel.ModifiedCounter.Name}" />
 
         <Label Grid.Row="1" Grid.Column="0">File:</Label>
         <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" IsReadOnly="True" Cursor="Arrow"
-                 VerticalScrollBarVisibility="Auto" Text="{Binding ConfigurationModel.SelectedPreset.SelectedCounter.File}" 
+                 VerticalScrollBarVisibility="Auto" Text="{Binding ApplicationStateModel.ModifiedCounter.File}" 
                  Interactivity:Commands.DoubleClickCommand="{Binding OpenCounterFileDialogCommand}" />
         <Button Grid.Row="1" Grid.Column="3" Margin="0,5,5,5" Width="20" Command="{Binding OpenCounterFileDialogCommand}">...</Button>
 
         <Label Grid.Row="2" Grid.Column="0">Count:</Label>
-        <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ConfigurationModel.SelectedPreset.SelectedCounter.Count}" x:Name="count" />
+        <TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ApplicationStateModel.ModifiedCounter.Count}" x:Name="count" />
 
         <Label Grid.Row="3" Grid.Column="0">Increment:</Label>
-        <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ConfigurationModel.SelectedPreset.SelectedCounter.Increment}" />
+        <TextBox Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Margin="5" Text="{Binding ApplicationStateModel.ModifiedCounter.Increment}" />
 
         <Label Grid.Row="4" Grid.Column="0">Format:</Label>
-        <TextBox Grid.Row="4" Grid.Column="1" Margin="5" Text="{Binding ConfigurationModel.SelectedPreset.SelectedCounter.Format}" x:Name="format" />
+        <TextBox Grid.Row="4" Grid.Column="1" Margin="5" Text="{Binding ApplicationStateModel.ModifiedCounter.Format}" x:Name="format" />
         <Label Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="2">
             <Label.Content>
                 <MultiBinding Converter="{StaticResource stringFormatConverter}">

--- a/DCSB.Views/DCSB.Views.csproj
+++ b/DCSB.Views/DCSB.Views.csproj
@@ -72,6 +72,9 @@
     <Compile Include="SettingsWindow\PresetView.xaml.cs">
       <DependentUpon>PresetView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="SettingsWindow\PresetConfigurationView.xaml.cs">
+      <DependentUpon>PresetConfigurationView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="SettingsWindow\SoundView.xaml.cs">
       <DependentUpon>SoundView.xaml</DependentUpon>
     </Compile>
@@ -105,6 +108,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="SettingsWindow\PresetView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="SettingsWindow\PresetConfigurationView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/DCSB.Views/MainWindow/CounterListView.xaml
+++ b/DCSB.Views/MainWindow/CounterListView.xaml
@@ -98,6 +98,7 @@
                                     IsReadOnly="True" 
                                     Binding="{Binding Path=Name}" />
                 <DataGridTemplateColumn Header="Count"
+                                        IsReadOnly="True"
                                         Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/DCSB.Views/MainWindow/SoundListView.xaml
+++ b/DCSB.Views/MainWindow/SoundListView.xaml
@@ -139,6 +139,7 @@
                                     IsReadOnly="True" 
                                     Binding="{Binding Name}" />
                 <DataGridTemplateColumn Header="Keys"
+                                        IsReadOnly="True"
                                         Width="*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml
+++ b/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml
@@ -1,0 +1,51 @@
+﻿<UserControl x:Class="DCSB.Views.SettingsWindow.PresetConfigurationView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:DCSB.Views.SettingsWindow"
+             xmlns:Controls="clr-namespace:DCSB.Controls;assembly=DCSB.Controls"
+             xmlns:Interactivity="clr-namespace:DCSB.Interactivity;assembly=DCSB.Interactivity"
+             xmlns:Converters="clr-namespace:DCSB.Converters;assembly=DCSB.Converters"
+             mc:Ignorable="d" 
+             d:DesignWidth="300">
+
+    <UserControl.Resources>
+        <Converters:VKeysToStringConverter x:Key="vKeysToStringConverter" />
+    </UserControl.Resources>
+    
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel>
+            <GroupBox Header="Presets">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+
+                    <local:PresetView Grid.Column="0"
+                                      DataContext="{Binding LeftPresetViewModel}" />
+
+                    <StackPanel Grid.Column="1"
+                                Orientation="Vertical"
+                                VerticalAlignment="Center">
+                        <Controls:IconButton Height="20"
+                                             Width="20"
+                                             ToolTip="Copy selected from left to right"
+                                             Content="{StaticResource RightArrowIcon}" 
+                                             Command="{Binding CopyCommand}" />
+                        <Controls:IconButton Height="20"
+                                             Width="20"
+                                             ToolTip="Copy selected from right to left"
+                                             Content="{StaticResource LeftArrowIcon}" 
+                                             Command="{Binding CopyCommand}" />
+                    </StackPanel>
+
+                    <local:PresetView Grid.Column="2"
+                                      DataContext="{Binding RightPresetViewModel}" />
+                </Grid>
+            </GroupBox>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml
+++ b/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml
@@ -24,23 +24,47 @@
                         <ColumnDefinition />
                     </Grid.ColumnDefinitions>
 
-                    <local:PresetView Grid.Column="0"
+                    <local:PresetView x:Name="Left"
+                                      Grid.Column="0"
                                       DataContext="{Binding LeftPresetViewModel}" />
 
-                    <StackPanel Grid.Column="1"
-                                Orientation="Vertical"
-                                VerticalAlignment="Center">
-                        <Controls:IconButton Height="20"
+                    <Grid Grid.Column="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="80"/>
+                            <RowDefinition />
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Grid.Row="1"
+                                    Orientation="Vertical"
+                                    VerticalAlignment="Center">
+                            <Controls:IconButton Height="20"
                                              Width="20"
-                                             ToolTip="Copy selected from left to right"
+                                             ToolTip="Copy selected Counters from left to right"
                                              Content="{StaticResource RightArrowIcon}" 
-                                             Command="{Binding CopyCommand}" />
-                        <Controls:IconButton Height="20"
+                                             Command="{Binding CopyCountersRightCommand}" />
+                            <Controls:IconButton Height="20"
                                              Width="20"
-                                             ToolTip="Copy selected from right to left"
+                                             ToolTip="Copy selected Counters from right to left"
                                              Content="{StaticResource LeftArrowIcon}" 
-                                             Command="{Binding CopyCommand}" />
-                    </StackPanel>
+                                             Command="{Binding CopyCountersLeftCommand}" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Row="2"
+                                    Orientation="Vertical"
+                                    VerticalAlignment="Center">
+                            <Controls:IconButton Height="20"
+                                             Width="20"
+                                             ToolTip="Copy selected Sounds from left to right"
+                                             Content="{StaticResource RightArrowIcon}" 
+                                             Command="{Binding CopySoundsRightCommand}" />
+                            <Controls:IconButton Height="20"
+                                             Width="20"
+                                             ToolTip="Copy selected Sounds from right to left"
+                                             Content="{StaticResource LeftArrowIcon}" 
+                                             Command="{Binding CopySoundsLeftCommand}" />
+                        </StackPanel>
+                    </Grid>
 
                     <local:PresetView Grid.Column="2"
                                       DataContext="{Binding RightPresetViewModel}" />

--- a/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml.cs
+++ b/DCSB.Views/SettingsWindow/PresetConfigurationView.xaml.cs
@@ -16,11 +16,11 @@ using System.Windows.Shapes;
 namespace DCSB.Views.SettingsWindow
 {
     /// <summary>
-    /// Interaction logic for Preset.xaml
+    /// Interaction logic for PresetView.xaml
     /// </summary>
-    public partial class PresetView : UserControl
+    public partial class PresetConfigurationView : UserControl
     {
-        public PresetView()
+        public PresetConfigurationView()
         {
             InitializeComponent();
         }

--- a/DCSB.Views/SettingsWindow/PresetView.xaml
+++ b/DCSB.Views/SettingsWindow/PresetView.xaml
@@ -4,50 +4,86 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:DCSB.Views.SettingsWindow"
+             xmlns:Converters="clr-namespace:DCSB.Converters;assembly=DCSB.Converters"
              xmlns:Controls="clr-namespace:DCSB.Controls;assembly=DCSB.Controls"
              xmlns:Interactivity="clr-namespace:DCSB.Interactivity;assembly=DCSB.Interactivity"
-             xmlns:Converters="clr-namespace:DCSB.Converters;assembly=DCSB.Converters"
              mc:Ignorable="d" 
-             d:DesignHeight="300"
              d:DesignWidth="300">
 
     <UserControl.Resources>
         <Converters:VKeysToStringConverter x:Key="vKeysToStringConverter" />
     </UserControl.Resources>
-    
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
-            <GroupBox Header="Presets">
-                <StackPanel>
-                    <ComboBox ItemsSource="{Binding ConfigurationModel.PresetCollection}"
-                              SelectedItem="{Binding ConfigurationModel.SelectedPreset}"
-                              DisplayMemberPath="Name" />
-                    <DockPanel>
-                        <Controls:IconButton DockPanel.Dock="Right" 
-                                             Margin="2" 
-                                             ToolTip="Remove Preset"
-                                             Content="{StaticResource RemoveIcon}" 
-                                             Command="{Binding RemovePresetCommand}" />
-                        <Controls:IconButton DockPanel.Dock="Right" 
-                                             Margin="2" 
-                                             ToolTip="Add Preset"
-                                             Content="{StaticResource AddIcon}"
-                                             Command="{Binding AddPresetCommand}" />
-                        <TextBox Name="NameField"
-                                 DockPanel.Dock="Left"
-                                 Margin="0,5"
-                                 Text="{Binding ConfigurationModel.SelectedPreset.Name, UpdateSourceTrigger=PropertyChanged}" />
-                    </DockPanel>
-                    <DockPanel>
-                        <Button DockPanel.Dock="Right" Width="20" Height="{Binding ActualHeight, ElementName=NameField}" Command="{Binding BindKeysCommand}" 
-                                CommandParameter="{Binding ConfigurationModel.SelectedPreset}" Margin="5,0,0,0">...</Button>
-                        <TextBox IsReadOnly="True" Cursor="Arrow" Height="{Binding ActualHeight, ElementName=NameField}"
-                                 Text="{Binding ConfigurationModel.SelectedPreset.Keys, Converter={StaticResource vKeysToStringConverter}}"
-                                 Interactivity:Commands.DoubleClickCommand="{Binding BindKeysCommand}"
-                                 Interactivity:Commands.DoubleClickCommandParameter="{Binding ConfigurationModel.SelectedPreset}" />
-                    </DockPanel>
-                </StackPanel>
-            </GroupBox>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <StackPanel Margin="3">
+            <ComboBox DisplayMemberPath="Name"
+                      SelectedItem="{Binding SelectedPreset}"
+                      ItemsSource="{Binding ConfigurationModel.PresetCollection}" />
+            <DockPanel>
+                <Controls:IconButton DockPanel.Dock="Right" 
+                                     Margin="2" 
+                                     ToolTip="Remove Preset"
+                                     Content="{StaticResource RemoveIcon}" 
+                                     Command="{Binding RemovePresetCommand}" />
+                <Controls:IconButton DockPanel.Dock="Right" 
+                                     Margin="2" 
+                                     ToolTip="Add Preset"
+                                     Content="{StaticResource AddIcon}"
+                                     Command="{Binding AddPresetCommand}" />
+                <Controls:IconButton DockPanel.Dock="Right" 
+                                     Margin="2" 
+                                     ToolTip="Copy Preset"
+                                     Content="{StaticResource CopyIcon}"
+                                     Command="{Binding ClonePresetCommand}" />
+                <TextBox Name="NameField"
+                         DockPanel.Dock="Left"
+                         Margin="0,5"
+                         Text="{Binding SelectedPreset.Name}" />
+            </DockPanel>
+
+            <DockPanel>
+                <Button DockPanel.Dock="Right" Width="20" Margin="5,0,0,0" Height="{Binding ActualHeight, ElementName=NameField}" 
+                        Command="{Binding BindKeysCommand}" CommandParameter="{Binding SelectedPreset}">...</Button>
+                <TextBox IsReadOnly="True" Cursor="Arrow" Height="{Binding ActualHeight, ElementName=NameField}"
+                         Text="{Binding SelectedPreset.Keys, Converter={StaticResource vKeysToStringConverter}}"
+                         Interactivity:Commands.DoubleClickCommand="{Binding BindKeysCommand}"
+                         Interactivity:Commands.DoubleClickCommandParameter="{Binding SelectedPreset}" />
+            </DockPanel>
         </StackPanel>
-    </ScrollViewer>
+
+        <ListView Grid.Row="1"
+                  Height="130"
+                  Margin="3"
+                  DisplayMemberPath="Name"
+                  ItemsSource="{Binding SelectedPreset.CounterCollection}">
+        </ListView>
+
+        <ListView Grid.Row="2"
+                  Height="130"
+                  Margin="3"
+                  DisplayMemberPath="Name"
+                  ItemsSource="{Binding SelectedPreset.SoundCollection}">
+
+            <!--<ListView.Resources>
+                <ContextMenu x:Key="RowMenu" DataContext="{Binding}">
+                    <MenuItem Header="Edit" 
+                              Command="{Binding DataContext.OpenSoundCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+                    <MenuItem Header="Remove" 
+                              Command="{Binding DataContext.RemoveSoundCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+                </ContextMenu>
+            </ListView.Resources>
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
+                </Style>
+            </ListView.ItemContainerStyle>-->
+        </ListView>
+    </Grid>
 </UserControl>

--- a/DCSB.Views/SettingsWindow/PresetView.xaml
+++ b/DCSB.Views/SettingsWindow/PresetView.xaml
@@ -61,29 +61,56 @@
                   Height="130"
                   Margin="3"
                   DisplayMemberPath="Name"
-                  ItemsSource="{Binding SelectedPreset.CounterCollection}">
+                  ItemsSource="{Binding SelectedPreset.CounterCollection}"
+                  Interactivity:AttachedProperties.SelectedItems="{Binding SelectedCounters}">
+
+            <ListView.Resources>
+                <ContextMenu x:Key="RowMenu" DataContext="{Binding}">
+                    <MenuItem Header="Edit" 
+                              Command="{Binding DataContext.OpenCounterCommand, RelativeSource={RelativeSource AncestorType=ListView}}" />
+                    <MenuItem Header="Remove" 
+                              Command="{Binding DataContext.RemoveCountersCommand, RelativeSource={RelativeSource AncestorType=ListView}}" />
+                </ContextMenu>
+            </ListView.Resources>
+
+            <ListView.InputBindings>
+                <KeyBinding Key="Delete" Command="{Binding RemoveCountersCommand}" />
+            </ListView.InputBindings>
+
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
+                </Style>
+            </ListView.ItemContainerStyle>
+
         </ListView>
 
         <ListView Grid.Row="2"
                   Height="130"
                   Margin="3"
                   DisplayMemberPath="Name"
-                  ItemsSource="{Binding SelectedPreset.SoundCollection}">
+                  ItemsSource="{Binding SelectedPreset.SoundCollection}"
+                  Interactivity:AttachedProperties.SelectedItems="{Binding SelectedSounds}">
 
-            <!--<ListView.Resources>
+            <ListView.Resources>
                 <ContextMenu x:Key="RowMenu" DataContext="{Binding}">
                     <MenuItem Header="Edit" 
-                              Command="{Binding DataContext.OpenSoundCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+                              Command="{Binding DataContext.OpenSoundCommand, RelativeSource={RelativeSource AncestorType=ListView}}" />
                     <MenuItem Header="Remove" 
-                              Command="{Binding DataContext.RemoveSoundCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" />
+                              Command="{Binding DataContext.RemoveSoundsCommand, RelativeSource={RelativeSource AncestorType=ListView}}" />
                 </ContextMenu>
             </ListView.Resources>
+
+            <ListView.InputBindings>
+                <KeyBinding Key="Delete" Command="{Binding RemoveSoundsCommand}" />
+            </ListView.InputBindings>
 
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
                     <Setter Property="ContextMenu" Value="{StaticResource RowMenu}" />
                 </Style>
-            </ListView.ItemContainerStyle>-->
+            </ListView.ItemContainerStyle>
+            
         </ListView>
     </Grid>
 </UserControl>

--- a/DCSB.Views/SettingsWindow/PresetView.xaml
+++ b/DCSB.Views/SettingsWindow/PresetView.xaml
@@ -73,6 +73,13 @@
                 </ContextMenu>
             </ListView.Resources>
 
+            <ListView.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Add" 
+                              Command="{Binding AddCounterCommand}"/>
+                </ContextMenu>
+            </ListView.ContextMenu>
+
             <ListView.InputBindings>
                 <KeyBinding Key="Delete" Command="{Binding RemoveCountersCommand}" />
             </ListView.InputBindings>
@@ -100,6 +107,13 @@
                               Command="{Binding DataContext.RemoveSoundsCommand, RelativeSource={RelativeSource AncestorType=ListView}}" />
                 </ContextMenu>
             </ListView.Resources>
+
+            <ListView.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Add" 
+                              Command="{Binding AddSoundCommand}"/>
+                </ContextMenu>
+            </ListView.ContextMenu>
 
             <ListView.InputBindings>
                 <KeyBinding Key="Delete" Command="{Binding RemoveSoundsCommand}" />

--- a/DCSB.Views/SoundView.xaml
+++ b/DCSB.Views/SoundView.xaml
@@ -25,30 +25,30 @@
         </Grid.RowDefinitions>
 
         <Label Grid.Row="0" Grid.Column="0">Name:</Label>
-        <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Text="{Binding ConfigurationModel.SelectedPreset.SelectedSound.Name}" />
+        <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Text="{Binding ApplicationStateModel.ModifiedSound.Name}" />
 
         <Label Grid.Row="1" Grid.Column="0">File/s:</Label>
         <TextBox Grid.Row="1" Grid.Column="1" Margin="5" IsReadOnly="True" AcceptsReturn="True" MaxHeight="250" 
                  VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" Cursor="Arrow"
-                 Text="{Binding ConfigurationModel.SelectedPreset.SelectedSound.Files, Converter={StaticResource concatStringsConverter}, ConverterParameter='&#x0a;'}"
+                 Text="{Binding ApplicationStateModel.ModifiedSound.Files, Converter={StaticResource concatStringsConverter}, ConverterParameter='&#x0a;'}"
                  Interactivity:Commands.DoubleClickCommand="{Binding OpenSoundFileDialogCommand}" />
         <Button Grid.Row="1" Grid.Column="2" Margin="0,5,5,5" Width="20" Command="{Binding OpenSoundFileDialogCommand}">...</Button>
 
         <Label Grid.Row="2" Grid.Column="0">Key/s:</Label>
         <TextBox Grid.Row="2" Grid.Column="1" Margin="5" IsReadOnly="True"
-                 Text="{Binding ConfigurationModel.SelectedPreset.SelectedSound.Keys, Converter={StaticResource vKeysToStringConverter}}"
+                 Text="{Binding ApplicationStateModel.ModifiedSound.Keys, Converter={StaticResource vKeysToStringConverter}}"
                  Interactivity:Commands.DoubleClickCommand="{Binding BindKeysCommand}"
-                 Interactivity:Commands.DoubleClickCommandParameter="{Binding ConfigurationModel.SelectedPreset.SelectedSound}" />
+                 Interactivity:Commands.DoubleClickCommandParameter="{Binding ApplicationStateModel.ModifiedSound}" />
         <Button Grid.Row="2" Grid.Column="2" Margin="0,5,5,5" Width="20" Command="{Binding BindKeysCommand}" 
-                CommandParameter="{Binding ConfigurationModel.SelectedPreset.SelectedSound}">...</Button>
+                CommandParameter="{Binding ApplicationStateModel.ModifiedSound}">...</Button>
 
         <Label Grid.Row="3" Grid.Column="0">Volume:</Label>
         <Slider Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Margin="5" Maximum="100" AutoToolTipPlacement="BottomRight"
                 IsMoveToPointEnabled="True" ToolTip="Change applies next time you play this sound"
-                Value="{Binding ConfigurationModel.SelectedPreset.SelectedSound.Volume}"/>
+                Value="{Binding ApplicationStateModel.ModifiedSound.Volume}"/>
 
         <Label Grid.Row="4" Grid.Column="0">Loop:</Label>
         <CheckBox Grid.Row="4" Grid.Column="1" Margin="5" ToolTip="Change applies next time you play this sound"
-                  IsChecked="{Binding ConfigurationModel.SelectedPreset.SelectedSound.Loop}" />
+                  IsChecked="{Binding ApplicationStateModel.ModifiedSound.Loop}" />
     </Grid>
 </UserControl>

--- a/DCSB/MainWindow.xaml
+++ b/DCSB/MainWindow.xaml
@@ -17,19 +17,19 @@
 
     <i:Interaction.Behaviors>
         <Interactivity:OpenCloseWindowBehavior WindowType="local:SettingsWindow" 
-                                               Open="{Binding SettingsOpened, Mode=TwoWay}" 
+                                               Open="{Binding ApplicationStateModel.SettingsOpened, Mode=TwoWay}" 
                                                DataContext="{Binding}" />
         <Interactivity:OpenCloseWindowBehavior WindowType="local:SoundWindow" 
-                                               Open="{Binding SoundOpened, Mode=TwoWay}" 
+                                               Open="{Binding ApplicationStateModel.SoundOpened, Mode=TwoWay}" 
                                                DataContext="{Binding}" />
         <Interactivity:OpenCloseWindowBehavior WindowType="local:CounterWindow" 
-                                               Open="{Binding CounterOpened, Mode=TwoWay}" 
+                                               Open="{Binding ApplicationStateModel.CounterOpened, Mode=TwoWay}" 
                                                DataContext="{Binding}" />
         <Interactivity:OpenCloseWindowBehavior WindowType="local:BindKeysWindow" 
-                                               Open="{Binding BindKeysOpened, Mode=TwoWay}" 
+                                               Open="{Binding ApplicationStateModel.BindKeysOpened, Mode=TwoWay}" 
                                                DataContext="{Binding}" />
         <Interactivity:OpenCloseWindowBehavior WindowType="local:AboutWindow" 
-                                               Open="{Binding AboutOpened, Mode=TwoWay}" 
+                                               Open="{Binding ApplicationStateModel.AboutOpened, Mode=TwoWay}" 
                                                DataContext="{Binding}" />
     </i:Interaction.Behaviors>
 

--- a/DCSB/MainWindow.xaml
+++ b/DCSB/MainWindow.xaml
@@ -15,6 +15,12 @@
         Height="{Binding ConfigurationModel.WindowHeight, Mode=TwoWay}"
         Width="{Binding ConfigurationModel.WindowWidth, Mode=TwoWay}">
 
+    <i:Interaction.Triggers>
+        <i:EventTrigger EventName="Closing">
+            <cmd:EventToCommand Command="{Binding ClosingCommand}" />
+        </i:EventTrigger>
+    </i:Interaction.Triggers>
+
     <i:Interaction.Behaviors>
         <Interactivity:OpenCloseWindowBehavior WindowType="local:SettingsWindow" 
                                                Open="{Binding ApplicationStateModel.SettingsOpened, Mode=TwoWay}" 

--- a/DCSB/SettingsWindow.xaml
+++ b/DCSB/SettingsWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:local="clr-namespace:DCSB"
         xmlns:Views="clr-namespace:DCSB.Views.SettingsWindow;assembly=DCSB.Views"
         Title="Settings"
-        Width="350"
+        Width="450"
         SizeToContent="Height"
         ShowInTaskbar="False"
         WindowStartupLocation="CenterOwner"
@@ -21,7 +21,7 @@
         </TabItem>
 
         <TabItem Header="Presets">
-            <Views:PresetView />
+            <Views:PresetConfigurationView DataContext="{Binding PresetConfigurationViewModel}" />
         </TabItem>
 
         <TabItem Header="Other">


### PR DESCRIPTION
Add copying presets.
Add two-preset view to settings that enables to copy Counters/Sounds between displayed presets and add, remove and edit individual Counters/Sounds.